### PR TITLE
Added ability to clear all civilian AI vehicles

### DIFF
--- a/script.lua
+++ b/script.lua
@@ -935,6 +935,11 @@ function onCustomCommand(full_message, peer_id, is_admin, is_auth, command, arg1
             end
         end
     end
+	if command == "?ai_clear" and is_admin then
+        for vehicle_id, _ in pairs(g_savedata.vehicles) do
+            server.despawnVehicle(vehicle_id, true)
+        end
+    end
 end
 
 function refuel(vehicle_id)


### PR DESCRIPTION
Added a basic command that can be used by the admin in an emergency to delete all the AI vehicles from the world, forcing them to slowly respawn again from zero.